### PR TITLE
28 - Adjust POST /pets endpoint (to accept birthdate as a timestamp)

### DIFF
--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -10,6 +10,7 @@ module API
 
       helpers Helpers::Auth
       helpers Helpers::Pagination
+      helpers Helpers::Params
       helpers Helpers::Response
 
       rescue_from Grape::Exceptions::ValidationErrors do |e|

--- a/app/controllers/api/v1/helpers/params.rb
+++ b/app/controllers/api/v1/helpers/params.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    module Helpers
+      module Params
+        def parsed_date
+          params["date"] ? Time.at(params["date"]) : nil
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/pets/create.rb
+++ b/app/controllers/api/v1/pets/create.rb
@@ -6,9 +6,9 @@ module API
       class Create < Base
         params do
           requires :name,        type: String
-          requires :kind,        type: String, values: Pet.kinds.keys # [cat, dog]
+          requires :kind,        type: String
           optional :breed,       type: String
-          optional :birthdate,   type: Date
+          optional :birthdate,   type: Integer
           optional :description, type: String
         end
 
@@ -19,7 +19,7 @@ module API
             name: params["name"],
             kind: params["kind"],
             breed: params["breed"],
-            birthdate: params["birthdate"],
+            birthdate: parsed_date,
             description: params["description"],
             owner: current_user
           )


### PR DESCRIPTION
Add helper responsible for param standarization
Add helper to base class
Refactor POST /pets endpoint - use param helper for birthdate